### PR TITLE
Misc circle color

### DIFF
--- a/application/src/org/yaaic/activity/ConversationActivity.java
+++ b/application/src/org/yaaic/activity/ConversationActivity.java
@@ -72,8 +72,8 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.View.OnKeyListener;
 import android.view.Window;
+import android.view.View.OnKeyListener;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.Button;
 import android.widget.EditText;
@@ -388,18 +388,27 @@ public class ConversationActivity extends Activity implements ServiceConnection,
 
         MessageListAdapter adapter = conversation.getMessageListAdapter();
 
-        conversation.setStatus(Conversation.STATUS_MESSAGE);
-
-        if (dots != null) {
-            dots.invalidate();
-        }
-
         while(conversation.hasBufferedMessages()) {
             Message message = conversation.pollBufferedMessage();
 
             if (adapter != null) {
                 adapter.addMessage(message);
+                int status;
+                switch (message.getType())
+                {
+                    case Message.TYPE_MISC:
+                        status = Conversation.STATUS_MISC;
+                        break;
+                    default:
+                        status = Conversation.STATUS_MESSAGE;
+                        break;
+                }
+                conversation.setStatus(status);
             }
+        }
+
+        if (dots != null) {
+            dots.invalidate();
         }
     }
 

--- a/application/src/org/yaaic/irc/IRCConnection.java
+++ b/application/src/org/yaaic/irc/IRCConnection.java
@@ -340,7 +340,8 @@ public class IRCConnection extends PircBot
             );
             service.sendBroadcast(intent);
         } else if (service.getSettings().showJoinAndPart()) {
-            Message message = new Message(service.getString(R.string.message_join, sender));
+            Message message = new Message(service.getString(R.string.message_join, sender),
+                Message.TYPE_MISC);
             message.setIcon(R.drawable.join);
             message.setColor(Message.COLOR_GREEN);
             server.getConversation(target).addMessage(message);
@@ -524,7 +525,8 @@ public class IRCConnection extends PircBot
             );
             service.sendBroadcast(intent);
         } else if (service.getSettings().showJoinAndPart()) {
-            Message message = new Message(service.getString(R.string.message_part, sender));
+            Message message = new Message(service.getString(R.string.message_part, sender),
+                Message.TYPE_MISC);
             message.setColor(Message.COLOR_GREEN);
             message.setIcon(R.drawable.part);
             server.getConversation(target).addMessage(message);
@@ -596,7 +598,8 @@ public class IRCConnection extends PircBot
             Vector<String> channels = getChannelsByNickname(sourceNick);
 
             for (String target : channels) {
-                Message message = new Message(service.getString(R.string.message_quit, sourceNick, reason));
+                Message message = new Message(service.getString(R.string.message_quit, sourceNick, reason),
+                    Message.TYPE_MISC);
                 message.setColor(Message.COLOR_GREEN);
                 message.setIcon(R.drawable.quit);
                 server.getConversation(target).addMessage(message);
@@ -613,7 +616,8 @@ public class IRCConnection extends PircBot
             Conversation conversation = server.getConversation(sourceNick);
 
             if (conversation != null) {
-                Message message = new Message(service.getString(R.string.message_quit, sourceNick, reason));
+                Message message = new Message(service.getString(R.string.message_quit, sourceNick, reason),
+                    Message.TYPE_MISC);
                 message.setColor(Message.COLOR_GREEN);
                 message.setIcon(R.drawable.quit);
                 conversation.addMessage(message);

--- a/application/src/org/yaaic/model/Conversation.java
+++ b/application/src/org/yaaic/model/Conversation.java
@@ -41,6 +41,8 @@ public abstract class Conversation
     public static final int STATUS_SELECTED  = 2;
     public static final int STATUS_MESSAGE   = 3;
     public static final int STATUS_HIGHLIGHT = 4;
+    /* join/part/quit */
+    public static final int STATUS_MISC      = 5;
 
     public static final int HISTORY_SIZE = 30;
 
@@ -177,6 +179,11 @@ public abstract class Conversation
 
         // Highlight status can only be changed by selecting
         if (this.status == STATUS_HIGHLIGHT && status != STATUS_SELECTED) {
+            return;
+        }
+
+        // Misc cannot change any other than default
+        if (this.status != STATUS_DEFAULT && status == STATUS_MISC) {
             return;
         }
 

--- a/application/src/org/yaaic/model/Message.java
+++ b/application/src/org/yaaic/model/Message.java
@@ -44,6 +44,11 @@ public class Message {
     public static final int COLOR_GREY    = 0xFFaaaaaa;
     public static final int COLOR_DEFAULT = 0xFFeeeeee;
 
+    /* normal message, this is the default */
+    public static final int TYPE_MESSAGE = 0;
+    /* join, part or quit */
+    public static final int TYPE_MISC    = 1;
+
     public static final int[] colors = {
         0xFFffffff, // White
         0xFFffff00, // Yellow
@@ -63,6 +68,7 @@ public class Message {
         0xFF000000, // Black
     };
 
+    private int type = -1;
     private int icon = -1;
     private final String text;
     private final String sender;
@@ -71,25 +77,51 @@ public class Message {
     private final long timestamp;
 
     /**
-     * Create a new message without an icon
+     * Create a new message without an icon defaulting to TYPE_MESSAGE
      * 
      * @param text
      */
     public Message(String text)
     {
-        this(text, null);
+        this(text, null, TYPE_MESSAGE);
     }
+
     /**
-     * Create a new message sent by a user without an icon
-     *
+     * Create a new message without an icon with a specific type
+     * 
+     * @param text
+     * @param type Message type
+     */
+    public Message(String text, int type)
+    {
+        this(text, null, type);
+    }
+
+    /**
+     * Create a new message sent by a user, without an icon,
+     * defaulting to TYPE_MESSAGE
+     * 
      * @param text
      * @param sender
      */
     public Message(String text, String sender)
     {
+        this(text, sender, TYPE_MESSAGE);
+    }
+
+    /**
+     * Create a new message sent by a user without an icon
+     *
+     * @param text
+     * @param sender
+     * @param type Message type
+     */
+    public Message(String text, String sender, int type)
+    {
         this.text = text;
         this.sender = sender;
         this.timestamp = new Date().getTime();
+        this.type = type;
     }
 
     /**
@@ -118,6 +150,16 @@ public class Message {
     public String getText()
     {
         return text;
+    }
+
+    /**
+     * Get the type of this message
+     * 
+     * @return One of Message.TYPE_*
+     */
+    public int getType()
+    {
+        return type;
     }
 
     /**

--- a/application/src/org/yaaic/view/ConversationSwitcher.java
+++ b/application/src/org/yaaic/view/ConversationSwitcher.java
@@ -110,6 +110,8 @@ public class ConversationSwitcher extends View
                 case Conversation.STATUS_SELECTED:
                     paint.setColor(0xFFFFFFFF);
                     break;
+                case Conversation.STATUS_MISC:
+                    paint.setColor(0xFF3333AA);
             }
 
             canvas.drawCircle(startX + 12 * i, height / 2, 4, paint);


### PR DESCRIPTION
Use a different color for join/part/quit for the circles in the ConversationSwitcher view.

This makes it easier to ignore unintersting messages wihout turning off the setting to show joins/parts/quits.
Once circle is colored for a new message, the join/part/quit cannot override it anymore.
