### PR TITLE
Allow for forward slashes in idents

### DIFF
--- a/application/src/org/yaaic/activity/AddServerActivity.java
+++ b/application/src/org/yaaic/activity/AddServerActivity.java
@@ -481,7 +481,7 @@ public class AddServerActivity extends SherlockActivity implements OnClickListen
         }
 
         // We currently only allow chars, numbers and some special chars for ident
-        Pattern identPattern = Pattern.compile("^[a-zA-Z0-9\\[\\]\\-_]+$");
+        Pattern identPattern = Pattern.compile("^[a-zA-Z0-9\\[\\]\\-_/]+$");
         if (!identPattern.matcher(ident).matches()) {
             throw new ValidationException(getResources().getString(R.string.validation_invalid_ident));
         }


### PR DESCRIPTION
I run znc-git and multiple network support was implemented.  Usernames for multiple network support follow the syntax of: username/network.  This should be added to allow for multiple network support with znc-git and future releases (unless something changes).
