### PR TITLE
New Feature: Optional highlights shown in server window

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,6 +17,7 @@ Development
  Reyncor                           https://github.com/Reyncor
  Darren Salt                       https://github.com/dsalt
  Daniel E. Moctezuma               https://github.com/democtezuma
+ Thomas Ramage                     https://github.com/GoodOldWar
 
 --------------------------------------------------------------------------------
 Graphics

--- a/application/res/values/settings.xml
+++ b/application/res/values/settings.xml
@@ -44,6 +44,9 @@
 
     <string name="key_led_highlight" translatable="false">led_highlight</string>
     <string name="default_led_highlight" translatable="false">true</string>
+    
+    <string name="key_highlight_notice" translatable="false">highlight_notice</string>
+    <string name="default_highlight_notice" translatable="false">false</string>
 
     <string name="key_notice_server_window" translatable="false">notice_server_window</string>
     <string name="default_notice_server_window" translatable="false">false</string>

--- a/application/res/values/strings.xml
+++ b/application/res/values/strings.xml
@@ -207,7 +207,9 @@
     <string name="settings_vibrate_highlight_desc">Vibrate when your nick is mentioned</string>
     <string name="settings_led_highlight_title">Flash LED on highlight</string>
     <string name="settings_led_highlight_desc">Flash LED light when your nick is mentioned</string>
-
+    <string name="settings_highlight_notice_title">Notice on Highlight</string>
+    <string name="settings_highlight_notice_desc">Display message in server window on highlight</string>
+    
     <string name="settings_misc">Misc</string>
     <string name="settings_quitmessage_title">Quit message</string>
     <string name="settings_quitmessage_desc">Message to show when you disconnect</string>

--- a/application/res/xml/preferences.xml
+++ b/application/res/xml/preferences.xml
@@ -139,6 +139,11 @@ along with Yaaic.  If not, see <http://www.gnu.org/licenses/>.
             android:summary="@string/settings_led_highlight_desc"
             android:key="@string/key_led_highlight"
             android:defaultValue="@string/default_led_highlight" />
+        <CheckBoxPreference
+            android:title="@string/settings_highlight_notice_title"
+            android:summary="@string/settings_highlight_notice_desc"
+            android:key="@string/key_highlight_notice"
+            android:defaultValue="@string/default_highlight_notice" />
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/settings_misc">

--- a/application/src/org/yaaic/irc/IRCConnection.java
+++ b/application/src/org/yaaic/irc/IRCConnection.java
@@ -313,6 +313,11 @@ public class IRCConnection extends PircBot
             // highlight
             message.setColor(Message.COLOR_RED);
             conversation.setStatus(Conversation.STATUS_HIGHLIGHT);
+            if (service.getSettings().isHighlightMsgEnabled())
+            {
+            	server.getConversation(ServerInfo.DEFAULT_NAME).addMessage(message);
+            	return;
+            }
         }
     }
 
@@ -475,6 +480,13 @@ public class IRCConnection extends PircBot
         if (isMentioned(text)) {
             // highlight
             message.setColor(Message.COLOR_RED);
+            
+            if (service.getSettings().isHighlightMsgEnabled())
+            {
+            	server.getConversation(ServerInfo.DEFAULT_NAME).addMessage(message);
+            	return;
+            }
+            
             if (conversation.getStatus() != Conversation.STATUS_SELECTED || !server.getIsForeground()) {
                 service.addNewMention(
                     server.getId(),
@@ -487,6 +499,7 @@ public class IRCConnection extends PircBot
             }
 
             conversation.setStatus(Conversation.STATUS_HIGHLIGHT);
+            
         }
 
         conversation.addMessage(message);

--- a/application/src/org/yaaic/model/Settings.java
+++ b/application/src/org/yaaic/model/Settings.java
@@ -235,6 +235,20 @@ public class Settings
             Boolean.parseBoolean(resources.getString(R.string.default_led_highlight))
         );
     }
+    
+    /**
+     * Send message to server window on highlight?
+     * 
+     * @return True if server window notice is enabled, false otherwise
+     */
+    public boolean isHighlightMsgEnabled()
+    {
+    	return preferences.getBoolean(
+    			resources.getString(R.string.key_highlight_notice),
+    			Boolean.parseBoolean(resources.getString(R.string.default_highlight_notice))
+    		);
+    			
+    }
 
     /**
      * Should join, part and quit messages be displayed?


### PR DESCRIPTION
Added an option that allows users to have their highlights shown in the server window, so they won't be lost in small buffers or busy chats. Also added myself to contributors.

Modified Yaaic files:
/res/values/strings.xml - added "settings_highlight_notice__" values in Highlight
/res/values/settings.xml - added "__highlight_notice" values for Highlight options
/res/xml/preferences.xml - added CheckBoxPreference to Highlight options
/src/org/yaaic/irc/IRCConnection.java - added service.getSettings().isHighlightMsgEnabled() and called it in relevant methods
/src/org/yaaic/model/Settings.java - added method isHighlightMsgEnabled()
