### PR TITLE
Add an option to show seconds in the timestamp

### DIFF
--- a/application/res/values/settings.xml
+++ b/application/res/values/settings.xml
@@ -15,6 +15,9 @@
     <string name="key_24h_format" translatable="false">24h_format</string>
     <string name="default_24h_format" translatable="false">true</string>
     
+    <string name="key_include_seconds" translatable="false">include_seconds</string>
+    <string name="default_include_seconds" translatable="false">true</string>
+
     <string name="key_reconnect" translatable="false">reconnect</string>
     <string name="default_reconnect" translatable="false">false</string>
     

--- a/application/res/values/strings.xml
+++ b/application/res/values/strings.xml
@@ -199,6 +199,8 @@
     <string name="settings_timestamp_desc">Prefix all messages with a timestamp</string>
     <string name="settings_24h_title">24 hour format</string>
     <string name="settings_24h_desc">Use 24 hour format for timestamps</string>
+    <string name="settings_include_seconds_title">Show seconds</string>
+    <string name="settings_include_seconds_desc">Include seconds in timestamps</string>
 
     <string name="settings_highlight">Highlight</string>
     <string name="settings_sound_highlight_title">Play sound on highlight</string>

--- a/application/res/xml/preferences.xml
+++ b/application/res/xml/preferences.xml
@@ -81,6 +81,12 @@ along with Yaaic.  If not, see <http://www.gnu.org/licenses/>.
             android:defaultValue="@string/default_24h_format"
             android:dependency="@string/key_show_timestamp" />
         <CheckBoxPreference
+            android:title="@string/settings_include_seconds_title"
+            android:summary="@string/settings_include_seconds_desc"
+            android:key="@string/key_include_seconds"
+            android:defaultValue="@string/default_include_seconds"
+            android:dependency="@string/key_show_timestamp" />
+        <CheckBoxPreference
             android:title="@string/settings_joinpartquit_title"
             android:summary="@string/settings_joinpartquit_desc"
             android:key="@string/key_show_joinpartquit"

--- a/application/src/org/yaaic/model/Message.java
+++ b/application/src/org/yaaic/model/Message.java
@@ -232,7 +232,7 @@ public class Message
         if (canvas == null) {
             String prefix    = hasIcon() && settings.showIcons() ? "  " : "";
             String nick      = hasSender() ? "<" + sender + "> " : "";
-            String timestamp = settings.showTimestamp() ? renderTimeStamp(settings.use24hFormat()) : "";
+            String timestamp = settings.showTimestamp() ? renderTimeStamp(settings.use24hFormat(), settings.includeSeconds()) : "";
 
             canvas = new SpannableString(prefix + timestamp + nick);
             SpannableString renderedText;
@@ -353,12 +353,13 @@ public class Message
      * @param use24hFormat
      * @return
      */
-    public String renderTimeStamp(boolean use24hFormat)
+    public String renderTimeStamp(boolean use24hFormat, boolean includeSeconds)
     {
         Date date = new Date(timestamp);
 
         int hours = date.getHours();
         int minutes = date.getMinutes();
+        int seconds = date.getSeconds();
 
         if (!use24hFormat) {
             hours = Math.abs(12 - hours);
@@ -367,6 +368,17 @@ public class Message
             }
         }
 
-        return "[" + (hours < 10 ? "0" + hours : hours) + ":" + (minutes < 10 ? "0" + minutes : minutes) + "] ";
+        if (includeSeconds) {
+            return String.format(
+                "[%02d:%02d:%02d]",
+                hours,
+                minutes,
+                seconds);
+        } else {
+            return String.format(
+                "[%02d:%02d]",
+                hours,
+                minutes);
+        }
     }
 }

--- a/application/src/org/yaaic/model/Settings.java
+++ b/application/src/org/yaaic/model/Settings.java
@@ -120,6 +120,20 @@ public class Settings
     }
 
     /**
+     * Include seconds in timestamps?
+     *
+     * @return
+     */
+    public boolean includeSeconds()
+    {
+        return preferences.getBoolean(
+            resources.getString(R.string.key_include_seconds),
+            Boolean.parseBoolean(resources.getString(R.string.default_include_seconds))
+        );
+    }
+
+
+    /**
      * Is reconnect on disconnect enabled?
      *
      * @return


### PR DESCRIPTION
I've made several changes, but this one was separate enough from my other changes that it was trivial to pull out and send upstream.

This optionally adds seconds to the timestamps, if timestamps are shown.
