### PR TITLE
Highlight on all nick aliases, not just the current nick.

### DIFF
--- a/application/src/org/yaaic/irc/IRCConnection.java
+++ b/application/src/org/yaaic/irc/IRCConnection.java
@@ -22,8 +22,10 @@ along with Yaaic.  If not, see <http://www.gnu.org/licenses/>.
 package org.yaaic.irc;
 
 import java.io.IOException;
+import java.lang.StringBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Vector;
 import java.util.regex.Pattern;
 
@@ -1317,7 +1319,16 @@ public class IRCConnection extends PircBot
      */
     private void updateNickMatchPattern()
     {
-        mNickMatch = Pattern.compile("(?:^|[\\s?!'�:;,.])"+Pattern.quote(getNick())+"(?:[\\s?!'�:;,.]|$)", Pattern.CASE_INSENSITIVE);
+        List<String> aliases = this.server.getIdentity().getAliases();
+        StringBuilder nicks = new StringBuilder();
+        nicks.append(Pattern.quote(getNick()));
+        for (String alias : aliases) {
+            nicks.append("|");
+            nicks.append(Pattern.quote(alias));
+        }
+        mNickMatch = Pattern.compile(
+            "(?:^|[\\s?!'�:;,.])" + nicks.toString() + "(?:[\\s?!'�:;,.]|$)",
+            Pattern.CASE_INSENSITIVE);
     }
 
     @Override


### PR DESCRIPTION
This makes it so that you can add alternate nicks as aliases (as normal) but allows you to get notifications if any of them are mentioned. It might be worth adding a toggle for enabling/disabling this (or even a separate `Identity` setting for "highlight nicks/patterns"), but I think in the general case, this is fine.

Specifically, I keep two clients connected - a znc for my phone, and an irssi instance for when I'm at home. (This is intentional, I'm in many channels on irssi, but only a few important ones on my phone). But I want to get notifications on my phone if my other nick (the irssi one) is mentioned. After this patch, I can just add it is an alias.
