### PR TITLE
Bump android-maven-plugin version for newer maven.

### DIFF
--- a/application/pom.xml
+++ b/application/pom.xml
@@ -77,7 +77,7 @@
         <plugins>
             <plugin>
                 <groupId>com.jayway.maven.plugins.android.generation2</groupId>
-                <version>3.5.0</version>
+                <version>3.8.0</version>
                 <artifactId>android-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>


### PR DESCRIPTION
This makes it so Yaaic builds again on Maven 3.1.x.