### PR TITLE
Fix capability list in CAP REQ when using SASL

### DIFF
--- a/pircbot/src/main/java/org/jibble/pircbot/PircBot.java
+++ b/pircbot/src/main/java/org/jibble/pircbot/PircBot.java
@@ -207,7 +207,7 @@ public abstract class PircBot implements ReplyConstants {
 
         if (saslUsername != null) {
             OutputThread.sendRawLine(this, bwriter, "CAP LS");
-            OutputThread.sendRawLine(this, bwriter, "CAP REQ : sasl multi-prefix");
+            OutputThread.sendRawLine(this, bwriter, "CAP REQ :sasl");
             OutputThread.sendRawLine(this, bwriter, "CAP END");
 
             OutputThread.sendRawLine(this, bwriter, "AUTHENTICATE PLAIN");


### PR DESCRIPTION
- Remove incorrect space character from the beginning of the capability list
- multi-prefix is not handled by Yaaic currently so don't request it