### PR TITLE
Solved Error:(1) Attribute insetForeground has already been defined. …

### DIFF
--- a/app/src/main/java/org/yaaic/view/ScrimInsetsFrameLayout.java
+++ b/app/src/main/java/org/yaaic/view/ScrimInsetsFrameLayout.java
@@ -59,7 +59,7 @@ public class ScrimInsetsFrameLayout extends FrameLayout {
         if (a == null) {
             return;
         }
-        mInsetForeground = a.getDrawable(R.styleable.ScrimInsetsView_scrimInsetForeground);
+        mInsetForeground = a.getDrawable(R.styleable.ScrimInsetsView_insetForegroundYaaic);
         a.recycle();
 
         setWillNotDraw(true);

--- a/app/src/main/res/layout/item_drawer.xml
+++ b/app/src/main/res/layout/item_drawer.xml
@@ -28,7 +28,7 @@ along with Yaaic.  If not, see <http://www.gnu.org/licenses/>.
     android:clickable="true"
     android:fitsSystemWindows="true"
     android:paddingTop="24dp"
-    app:scrimInsetForeground="@color/primary_dark">
+    app:insetForegroundYaaic="@color/primary_dark">
 
     <LinearLayout
         android:id="@+id/drawer_content"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,5 +1,5 @@
 <resources>
     <declare-styleable name="ScrimInsetsView">
-        <attr name="scrimInsetForeground" format="reference|color" />
+        <attr name="insetForegroundYaaic" format="reference|color" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
…The NavigationDrawer extends ScrimInsetsFrameLayout which was brought into the library.The error in occurs because the insetForeground attribute was defined twice.